### PR TITLE
transport/efa-gda: Update efa-gda transport for sequence tracking

### DIFF
--- a/src/include/device_host_transport/nvshmem_common_efagda.h
+++ b/src/include/device_host_transport/nvshmem_common_efagda.h
@@ -22,6 +22,7 @@
 
 #include "device_host/nvshmem_types.h"
 #include "non_abi/device/pt-to-pt/efa_io_defs.h"
+#include "non_abi/device/pt-to-pt/libfabric_efagda_common.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -119,7 +120,7 @@ typedef struct {
     int log2_cumem_granularity;
     uint32_t n_pes;
     uint32_t my_pe;
-    uint32_t *put_signal_seq_counter;
+    nvshmemt_libfabric_endpoint_seq_counter_t *put_signal_seq_counter;
     struct efa_qp *cuda_qp;
     struct efa_cq *cuda_cq;
     struct cuda_ah_info *cuda_ah;

--- a/src/include/non_abi/device/pt-to-pt/efagda_device.cuh
+++ b/src/include/non_abi/device/pt-to-pt/efagda_device.cuh
@@ -14,6 +14,7 @@
 #include "non_abi/device/common/nvshmemi_common_device.cuh"
 #include "non_abi/device/threadgroup/nvshmemi_common_device_defines.cuh"
 #include "device_host_transport/nvshmem_common_efagda.h"
+#include "non_abi/device/pt-to-pt/libfabric_efagda_common.h"
 #include <stdio.h>
 
 #include <limits.h>
@@ -630,7 +631,19 @@ __device__ NVSHMEMI_DEVICE_ALWAYS_INLINE void nvshmemi_efagda_quiet() {
                             state->my_pe, (unsigned long)wc.wr_id, (unsigned long)wc.vendor_err, (unsigned long)wc.opcode);
                     __trap();
                 }
+
                 state->cuda_qp->sq.wq.wqes_completed++;
+                if (wc.opcode == EFAGDA_WC_RECV_RDMA_WITH_IMM) {
+                    /* wc.imm_data is in big-endian */
+                    uint32_t imm_data = BSWAP32(wc.imm_data);
+                    /* Make sure this is an ack. */
+                    assert((imm_data >> NVSHMEM_STAGED_AMO_PUT_SIGNAL_SEQ_CNTR_BIT_SHIFT) ==
+                            NVSHMEMT_LIBFABRIC_IMM_STAGED_ATOMIC_ACK);
+                    uint32_t seq_num = imm_data & NVSHMEM_STAGED_AMO_PUT_SIGNAL_SEQ_CNTR_BIT_MASK;
+                    if (seq_num != NVSHMEM_STAGED_AMO_SEQ_NUM) {
+                        state->put_signal_seq_counter->return_acked_seq_num(seq_num);
+                    }
+                }
             }
         }
        efagda_lock_release<NVSHMEMI_THREADGROUP_THREAD>(state->rx_lock);
@@ -649,7 +662,11 @@ __device__ NVSHMEMI_DEVICE_ALWAYS_INLINE void nvshmemi_efagda_put_signal(
         efagda_lock_acquire<NVSHMEMI_THREADGROUP_THREAD>(state->tx_lock);
         struct efa_qp *qp = state->cuda_qp;
 
-        *state->put_signal_seq_counter = (*state->put_signal_seq_counter + 1) & 0xFFFFFFF;
+        uint32_t seq_num = state->put_signal_seq_counter->next_seq_num();
+        if (!state->put_signal_seq_counter->acquire_seq_num(seq_num)) {
+            /* TODO Here we need to poll the completion queue until the sequence number is available */
+            assert(0);
+        }
 
         uint16_t ah;
         uint16_t remote_qpn;
@@ -674,7 +691,7 @@ __device__ NVSHMEMI_DEVICE_ALWAYS_INLINE void nvshmemi_efagda_put_signal(
 
             size_t transfer_size = efagda_cal_transfer_size(remaining_size, lchunk_size, rchunk_size);
 
-            efagda_init_rdma_write_imm_wr(qp, 0, rkey, raddr, *state->put_signal_seq_counter);
+            efagda_init_rdma_write_imm_wr(qp, 0, rkey, raddr, seq_num);
             efagda_wr_set_remote_addr(qp, ah, remote_qpn, remote_qkey);
             efagda_wr_set_sge(qp, lkey, laddr, transfer_size);
             efagda_finalize_send_wr(qp);
@@ -695,7 +712,7 @@ __device__ NVSHMEMI_DEVICE_ALWAYS_INLINE void nvshmemi_efagda_put_signal(
         nvshmemt_efagda_signal_op_t signal_op;
         signal_op.type = 2; // NVSHMEMT_LIBFABRIC_MATCH
         signal_op.op = sig_op;
-        signal_op.sequence_count = *state->put_signal_seq_counter;
+        signal_op.sequence_count = seq_num;
         signal_op.target_addr = (void*)sig_raddr;
         signal_op.sig_val = signal;
         signal_op.num_writes = num_writes;

--- a/src/include/non_abi/device/pt-to-pt/libfabric_efagda_common.h
+++ b/src/include/non_abi/device/pt-to-pt/libfabric_efagda_common.h
@@ -1,0 +1,156 @@
+/*
+ * Copyright (c) Amazon.com, Inc. or its affiliates. All rights reserved.
+ *
+ * See COPYRIGHT for license information
+ */
+
+#ifndef _NVSHMEMI_LIBFABRIC_EFAGDA_COMMON_H_
+#define _NVSHMEMI_LIBFABRIC_EFAGDA_COMMON_H_
+
+#include <cuda_runtime.h>
+#include <stdint.h>
+#include <string.h>
+#include <assert.h>
+#include <stdio.h>
+
+#define NVSHMEM_STAGED_AMO_PUT_SIGNAL_SEQ_CNTR_BIT_SHIFT 28
+#define NVSHMEM_STAGED_AMO_PUT_SIGNAL_SEQ_CNTR_BIT_MASK ((1U << NVSHMEM_STAGED_AMO_PUT_SIGNAL_SEQ_CNTR_BIT_SHIFT) - 1)
+
+/**
+ * The last sequence number is reserved for atomic-only operations.
+ * This will not be returned by the sequence counter.
+ */
+#define NVSHMEM_STAGED_AMO_SEQ_NUM NVSHMEM_STAGED_AMO_PUT_SIGNAL_SEQ_CNTR_BIT_MASK
+
+/**
+ * Type used for tracking sequence numbers for put-signal operations
+ *
+ * A sequence number is associated with each put-signal operation. This type
+ * manages allocation of sequence numbers and return of sequence numbers via
+ * acks from the remote side.
+ */
+struct nvshmemt_libfabric_endpoint_seq_counter_t {
+
+    constexpr static uint32_t num_sequence_bits = NVSHMEM_STAGED_AMO_PUT_SIGNAL_SEQ_CNTR_BIT_SHIFT;
+
+    /**
+     * Sequence counter is composed of:
+     *
+     * |----------<num_sequence_bits>----------|
+     * | <num_category_bits> <num_index_bits>  |
+     */
+    constexpr static uint32_t num_category_bits = 1;
+    constexpr static uint32_t num_categories = (1U << num_category_bits);
+
+    constexpr static uint32_t num_index_bits = (num_sequence_bits - num_category_bits);
+
+    constexpr static uint32_t index_mask = ((1U << num_index_bits) - 1);
+    constexpr static uint32_t category_mask = (1U << num_index_bits);
+
+    constexpr static uint32_t sequence_mask = NVSHMEM_STAGED_AMO_PUT_SIGNAL_SEQ_CNTR_BIT_MASK;
+
+    /**
+     * The "category" is the bits before the index bit(s). Returns the category
+     * bits shifted to the right.
+     */
+    constexpr __host__ __device__ static uint32_t get_category(uint32_t seq_num)
+    {
+        return ((seq_num & category_mask) >> num_index_bits);
+    }
+
+    /**
+     * The "index" is the bits after the category bit(s)
+     */
+    constexpr __host__ __device__ static uint32_t get_index(uint32_t seq_num)
+    {
+        return seq_num & index_mask;
+    }
+
+    /* ------------------------------ */
+    /* Member variables */
+
+    uint32_t sequence_counter;
+    uint32_t pending_acks[num_categories];
+
+    /**
+     * Reset counter and pending acks to zero
+     */
+    __host__ __device__ void reset()
+    {
+        sequence_counter = 0;
+        memset(pending_acks, 0, sizeof(pending_acks));
+    }
+
+    /**
+     * Obtain the next sequence number.
+     */
+    __host__ __device__ inline uint32_t next_seq_num()
+    {
+#ifdef __CUDA_ARCH__
+        /* Note: on CUDA, the counter update needs to be atomic to account for multiple
+           threads submitting a TX simultaneously. On host, this code is all locked so
+           no special handling is needed. */
+        return atomicInc(&sequence_counter, NVSHMEM_STAGED_AMO_SEQ_NUM);
+#else
+        uint32_t seq_num = sequence_counter++;
+        if (sequence_counter == NVSHMEM_STAGED_AMO_SEQ_NUM) {
+            sequence_counter = 0;
+        }
+        return seq_num;
+#endif /* __CUDA_ARCH__ */
+    }
+
+    /**
+     * Acquire sequence number
+     */
+    __host__ __device__ inline bool acquire_seq_num(uint32_t seq_num)
+    {
+        uint32_t category = get_category(seq_num);
+
+        /* For first sequence number of category, check if category is available */
+        if (get_index(seq_num) == 0) {
+            if (pending_acks[category] != 0) {
+                /* No sequence number available */
+                return false;
+            }
+        }
+
+#ifdef __CUDA_ARCH__
+        uint32_t current = atomicAdd(&pending_acks[category], 1);
+#else
+        uint32_t current = pending_acks[category]++;
+#endif /* __CUDA_ARCH__ */
+
+        /* Can't have more outstanding acks than sequence numbers in the category */
+        assert(current <= index_mask);
+
+        return true;
+    }
+
+    /**
+     * Mark a previously issued seq_num as complete, decremeting the pending
+     * acks counter for the category
+     */
+    __device__ __host__ inline void return_acked_seq_num(uint32_t seq_num)
+    {
+        assert(seq_num != NVSHMEM_STAGED_AMO_SEQ_NUM);
+
+        uint32_t category = get_category(seq_num);
+
+        assert(category < num_categories);
+
+#ifdef __CUDA_ARCH__
+        uint32_t current = atomicSub(&pending_acks[category], 1);
+#else
+        uint32_t current = pending_acks[category]--;
+#endif /* __CUDA_ARCH__ */
+        assert(current > 0);
+    }
+};
+
+typedef enum {
+    NVSHMEMT_LIBFABRIC_IMM_PUT_SIGNAL_SEQ = 0,
+    NVSHMEMT_LIBFABRIC_IMM_STAGED_ATOMIC_ACK,
+} nvshmemt_libfabric_imm_cq_data_hdr_t;
+
+#endif /* _NVSHMEMI_LIBFABRIC_EFAGDA_COMMON_H_ */

--- a/src/modules/transport/efagda/efagda.cpp
+++ b/src/modules/transport/efagda/efagda.cpp
@@ -517,7 +517,6 @@ static int nvshmemt_efagda_populate_device_state(nvshmem_transport_t t) {
     int status = 0;
     nvshmemt_efagda_state_t *efagda_state = (nvshmemt_efagda_state_t *)t->state;
     nvshmemi_efagda_device_state_t *device_state = (nvshmemi_efagda_device_state_t *)t->type_specific_shared_state;
-    uint32_t initial_value = 0;
 
     if (!device_state) {
         NVSHMEMI_ERROR_JMP(status, NVSHMEMX_ERROR_INTERNAL, out, "type_specific_shared_state is NULL\n");
@@ -533,11 +532,11 @@ static int nvshmemt_efagda_populate_device_state(nvshmem_transport_t t) {
     device_state->cuda_ah = efagda_state->cuda_ah;
 
 
-    status = cudaMalloc(&efagda_state->put_signal_seq_counter, sizeof(uint32_t));
+    status = cudaMalloc(&efagda_state->put_signal_seq_counter, sizeof(nvshmemt_libfabric_endpoint_seq_counter_t));
     NVSHMEMI_NE_ERROR_JMP(status, cudaSuccess, NVSHMEMX_ERROR_OUT_OF_MEMORY, out, "cudaMalloc for put_signal_seq_counter failed.\n");
 
-    status = cudaMemcpy(efagda_state->put_signal_seq_counter, &initial_value, sizeof(uint32_t), cudaMemcpyHostToDevice);
-    NVSHMEMI_NE_ERROR_JMP(status, cudaSuccess, NVSHMEMX_ERROR_INTERNAL, out, "cudaMemcpy for put_signal_seq_counter initialization failed.\n");
+    status = cudaMemset(efagda_state->put_signal_seq_counter, 0, sizeof(nvshmemt_libfabric_endpoint_seq_counter_t));
+    NVSHMEMI_NE_ERROR_JMP(status, cudaSuccess, NVSHMEMX_ERROR_INTERNAL, out, "cudaMemset for put_signal_seq_counter initialization failed.\n");
     device_state->put_signal_seq_counter = efagda_state->put_signal_seq_counter;
 
     // Allocate tx lock in device memory

--- a/src/modules/transport/efagda/efagda.h
+++ b/src/modules/transport/efagda/efagda.h
@@ -7,6 +7,7 @@
 #include "libfabric.h"
 #include <vector>
 #include "device_host_transport/nvshmem_common_efagda.h"
+#include "non_abi/device/pt-to-pt/libfabric_efagda_common.h"
 
 // EFA GDA specific memory handle (following IBGDA pattern)
 typedef struct {
@@ -36,5 +37,5 @@ typedef struct {
     nvshmemi_efagda_device_key_t *device_lkeys_d;
     nvshmemi_efagda_device_key_t *device_rkeys_d;
 
-    uint32_t *put_signal_seq_counter;
+    nvshmemt_libfabric_endpoint_seq_counter_t *put_signal_seq_counter;
 } nvshmemt_efagda_state_t;

--- a/src/modules/transport/libfabric/libfabric.cpp
+++ b/src/modules/transport/libfabric/libfabric.cpp
@@ -1014,14 +1014,10 @@ int nvshmemt_put_signal_unordered(struct nvshmem_transport *tcurr, int pe, rma_v
 
     /* Get sequence number for this put-signal, with retry */
     uint64_t num_retries = 0;
+    sequence_count = ep.put_signal_seq_counter.next_seq_num();
     do {
-        int32_t seq_num = ep.put_signal_seq_counter.next_seq_num();
-        if (seq_num < 0) {
-            status = -EAGAIN;
-        } else {
-            sequence_count = seq_num;
-            status = 0;
-        }
+        bool acquired = ep.put_signal_seq_counter.acquire_seq_num(sequence_count);
+        status = (acquired ? 0 : -EAGAIN);
     } while (try_again(tcurr, &status, &num_retries, is_proxy));
 
     if (unlikely(status)) {

--- a/src/modules/transport/libfabric/libfabric.h
+++ b/src/modules/transport/libfabric/libfabric.h
@@ -21,6 +21,7 @@
 #include "device_host_transport/nvshmem_common_transport.h"
 #include "internal/host_transport/transport.h"
 #include "internal/host_transport/cudawrap.h"
+#include "non_abi/device/pt-to-pt/libfabric_efagda_common.h"
 
 #ifdef NVSHMEM_USE_GDRCOPY
 #include "gdrapi.h"
@@ -66,123 +67,6 @@ typedef struct {
 struct nvshmemt_libfabric_gdr_op_ctx;
 typedef struct nvshmemt_libfabric_gdr_op_ctx nvshmemt_libfabric_gdr_op_ctx_t;
 
-#define NVSHMEM_STAGED_AMO_PUT_SIGNAL_SEQ_CNTR_BIT_SHIFT 28
-#define NVSHMEM_STAGED_AMO_PUT_SIGNAL_SEQ_CNTR_BIT_MASK ((1U << NVSHMEM_STAGED_AMO_PUT_SIGNAL_SEQ_CNTR_BIT_SHIFT) - 1)
-
-/**
- * The last sequence number is reserved for atomic-only operations.
- * This will not be returned by the sequence counter.
- */
-#define NVSHMEM_STAGED_AMO_SEQ_NUM NVSHMEM_STAGED_AMO_PUT_SIGNAL_SEQ_CNTR_BIT_MASK
-
-/**
- * Type used for tracking sequence numbers for put-signal operations
- *
- * A sequence number is associated with each put-signal operation. This type
- * manages allocation of sequence numbers and return of sequence numbers via
- * acks from the remote side.
- */
-struct nvshmemt_libfabric_endpoint_seq_counter_t {
-
-    constexpr static uint32_t num_sequence_bits = NVSHMEM_STAGED_AMO_PUT_SIGNAL_SEQ_CNTR_BIT_SHIFT;
-
-    /**
-     * Sequence counter is composed of:
-     *
-     * |----------<num_sequence_bits>----------|
-     * | <num_category_bits> <num_index_bits>  |
-     */
-    constexpr static uint32_t num_category_bits = 1;
-    constexpr static uint32_t num_categories = (1U << num_category_bits);
-
-    constexpr static uint32_t num_index_bits = (num_sequence_bits - num_category_bits);
-
-    constexpr static uint32_t index_mask = ((1U << num_index_bits) - 1);
-    constexpr static uint32_t category_mask = (1U << num_index_bits);
-
-    constexpr static uint32_t sequence_mask = NVSHMEM_STAGED_AMO_PUT_SIGNAL_SEQ_CNTR_BIT_MASK;
-
-    /**
-     * The "category" is the bits before the index bit(s). Returns the category
-     * bits shifted to the right.
-     */
-    constexpr static uint32_t get_category(uint32_t seq_num)
-    {
-        return ((seq_num & category_mask) >> num_index_bits);
-    }
-
-    /**
-     * The "index" is the bits after the category bit(s)
-     */
-    constexpr static uint32_t get_index(uint32_t seq_num)
-    {
-        return seq_num & index_mask;
-    }
-
-    /* ------------------------------ */
-    /* Member variables */
-
-    uint32_t sequence_counter;
-    uint32_t pending_acks[num_categories];
-
-    /**
-     * Reset counter and pending acks to zero
-     */
-    void reset()
-    {
-        sequence_counter = 0;
-        memset(pending_acks, 0, sizeof(pending_acks));
-    }
-
-    /**
-     * Obtain the next sequence number.
-     *
-     * @return -1 if no sequence number available
-     */
-    int32_t next_seq_num()
-    {
-        /* Skip this sequence number if reserved */
-        if (sequence_counter == NVSHMEM_STAGED_AMO_SEQ_NUM) {
-            sequence_counter = (sequence_counter + 1) & sequence_mask;
-        }
-
-        uint32_t seq_num = sequence_counter;
-
-        uint32_t category = get_category(seq_num);
-
-        /* For first sequence number of category, check if category is available */
-        if (get_index(seq_num) == 0) {
-            if (pending_acks[category] != 0) {
-                /* No sequence number available */
-                return -1;
-            }
-        }
-
-        /* Can't have more outstanding acks than sequence numbers in the category */
-        assert(pending_acks[category] <= index_mask);
-        /* Increment pending acks */
-        ++pending_acks[category];
-
-        /* Increment sequence counter */
-        sequence_counter = (sequence_counter + 1) & sequence_mask;
-        return seq_num;
-    }
-
-    /**
-     * Mark a previously issued seq_num as complete, decremeting the pending
-     * acks counter for the category
-     */
-    void return_acked_seq_num(uint32_t seq_num)
-    {
-        assert(seq_num != NVSHMEM_STAGED_AMO_SEQ_NUM);
-
-        uint32_t category = get_category(seq_num);
-
-        assert(pending_acks[category] > 0);
-        --pending_acks[category];
-    }
-};
-
 typedef struct {
     struct fid_ep *endpoint;
     struct fid_cq *cq;
@@ -205,11 +89,6 @@ typedef enum {
     NVSHMEMT_LIBFABRIC_CONTEXT_SEND_AMO,
     NVSHMEMT_LIBFABRIC_CONTEXT_RECV_AMO
 } nvshemmt_libfabric_context_t;
-
-typedef enum {
-    NVSHMEMT_LIBFABRIC_IMM_PUT_SIGNAL_SEQ = 0,
-    NVSHMEMT_LIBFABRIC_IMM_STAGED_ATOMIC_ACK,
-} nvshmemt_libfabric_imm_cq_data_hdr_t;
 
 class threadSafeOpQueue {
    private:


### PR DESCRIPTION
A previous commit introduced a category bit to track outstanding sequence numbers to prevent overflow. This commit updates the interface to work better with EFAGDA, and updates the EFAGDA TX side to respect the protocol.